### PR TITLE
0.1.4

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,11 +3,13 @@ on:
   workflow_dispatch:
   schedule:
   - cron: "0 0 * * *"
+permissions:
+  actions: write
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been automatically marked as stale because it has not had activity in 14 days. It will be closed if no further activity occurs in 7 days'
@@ -19,3 +21,7 @@ jobs:
         days-before-issue-close: 7
         days-before-pr-close: -1
         exempt-issue-labels: 'bug,enhancement'
+    - uses: actions/checkout@v4
+    - uses: gautamkrishnar/keepalive-workflow@v2
+      with:
+        use_api: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,8 @@ on:
   workflow_dispatch:
   schedule:
   - cron: "0 0 * * *"
-permissions:
-  actions: write
+# permissions:
+#  actions: write
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -21,7 +21,7 @@ jobs:
         days-before-issue-close: 7
         days-before-pr-close: -1
         exempt-issue-labels: 'bug,enhancement'
-    - uses: actions/checkout@v4
-    - uses: gautamkrishnar/keepalive-workflow@v2
-      with:
-        use_api: true
+#    - uses: actions/checkout@v4
+#    - uses: gautamkrishnar/keepalive-workflow@v2
+#      with:
+#        use_api: true

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Calanish](https://github.com/calanish)
 - [Will O](https://github.com/4wrxb)
 - [Lachlan Bell](https://lachy.io/)
+
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Stephen Berry](https://github.com/berrystephenw)
 - [Guyot François](https://github.com/iFrostizz)
 - [Steve Dougherty](https://github.com/Thynix)
+- [Flying Buffalo Aerial Photography](http://flyingbuffalo.info/)
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Andrew Beeman](https://github.com/Kiendeleo)
 - [Calanish](https://github.com/calanish)
 - [Lachlan Bell](https://lachy.io/)
-- [Johnny Bergdal](https://github.com/bergdahl)
+- [Jonny Bergdahl](https://github.com/bergdahl)
 - [Leigh Johnson](https://github.com/leigh-johnson)
 - [Stephen Berry](https://github.com/berrystephenw)
 - [Steve Dougherty](https://github.com/Thynix)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [@Mearman](https://github.com/Mearman)
 - [@TheTuxKeeper](https://github.com/thetuxkeeper)
 - [@tideline3d](https://github.com/tideline3d/)
-- [OctoFarm](https://octofarm.net/)
 - [SimplyPrint](https://simplyprint.dk/)
 - [Andrew Beeman](https://github.com/Kiendeleo)
 - [Calanish](https://github.com/calanish)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Guyot François](https://github.com/iFrostizz)
 - César Romero
 - [Steve Dougherty](https://github.com/Thynix)
-
+- [Kyle Menigoz](https://menigoz.me)
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Andrew Beeman](https://github.com/Kiendeleo)
 - [Calanish](https://github.com/calanish)
 - [Will O](https://github.com/4wrxb)
-
-### Support My Efforts
+- [Lachlan Bell](https://lachy.io/)
+## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.
 
 [![Patreon](patreon-with-text-new.png)](https://www.patreon.com/jneilliii) [![paypal](paypal-with-text.png)](https://paypal.me/jneilliii)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Guyot François](https://github.com/iFrostizz)
 - [Steve Dougherty](https://github.com/Thynix)
 - [Flying Buffalo Aerial Photography](http://flyingbuffalo.info/)
+- Sam Fingard
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Stephen Berry](https://github.com/berrystephenw)
 - [Guyot François](https://github.com/iFrostizz)
 - [Steve Dougherty](https://github.com/Thynix)
-- [Kyle Menigoz](https://menigoz.me)
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.
 

--- a/README.md
+++ b/README.md
@@ -65,15 +65,18 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 ### Sponsors
 - Andreas Lindermayr
 - [@Mearman](https://github.com/Mearman)
-- [@TxBillbr](https://github.com/TxBillbr)
-- Gerald Dachs
 - [@TheTuxKeeper](https://github.com/thetuxkeeper)
-- @tideline3d
+- [@tideline3d](https://github.com/tideline3d/)
 - [SimplyPrint](https://simplyprint.dk/)
 - [Andrew Beeman](https://github.com/Kiendeleo)
 - [Calanish](https://github.com/calanish)
 - [Will O](https://github.com/4wrxb)
 - [Lachlan Bell](https://lachy.io/)
+- [Johnny Bergdal](https://github.com/bergdahl)
+- [Leigh Johnson](https://github.com/leigh-johnson)
+- [Stephen Berry](https://github.com/berrystephenw)
+- [Guyot François](https://github.com/iFrostizz)
+- César Romero
 
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [SimplyPrint](https://simplyprint.dk/)
 - [Andrew Beeman](https://github.com/Kiendeleo)
 - [Calanish](https://github.com/calanish)
-- [Will O](https://github.com/4wrxb)
 - [Lachlan Bell](https://lachy.io/)
 - [Johnny Bergdal](https://github.com/bergdahl)
 - [Leigh Johnson](https://github.com/leigh-johnson)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [@Mearman](https://github.com/Mearman)
 - [@TheTuxKeeper](https://github.com/thetuxkeeper)
 - [@tideline3d](https://github.com/tideline3d/)
+- [OctoFarm](https://octofarm.net/)
 - [SimplyPrint](https://simplyprint.dk/)
 - [Andrew Beeman](https://github.com/Kiendeleo)
 - [Calanish](https://github.com/calanish)

--- a/README.md
+++ b/README.md
@@ -64,19 +64,15 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 
 ### Sponsors
 - Andreas Lindermayr
-- [@Mearman](https://github.com/Mearman)
 - [@TheTuxKeeper](https://github.com/thetuxkeeper)
 - [@tideline3d](https://github.com/tideline3d/)
-- [SimplyPrint](https://simplyprint.dk/)
 - [Andrew Beeman](https://github.com/Kiendeleo)
 - [Calanish](https://github.com/calanish)
 - [Lachlan Bell](https://lachy.io/)
 - [Johnny Bergdal](https://github.com/bergdahl)
 - [Leigh Johnson](https://github.com/leigh-johnson)
 - [Stephen Berry](https://github.com/berrystephenw)
-- [Guyot François](https://github.com/iFrostizz)
 - [Steve Dougherty](https://github.com/Thynix)
-- [Flying Buffalo Aerial Photography](http://flyingbuffalo.info/)
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Stephen Berry](https://github.com/berrystephenw)
 - [Guyot François](https://github.com/iFrostizz)
 - César Romero
+- [Steve Dougherty](https://github.com/Thynix)
 
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Calanish](https://github.com/calanish)
 - [Lachlan Bell](https://lachy.io/)
 - [Jonny Bergdahl](https://github.com/bergdahl)
-- [Leigh Johnson](https://github.com/leigh-johnson)
 - [Stephen Berry](https://github.com/berrystephenw)
 - [Steve Dougherty](https://github.com/Thynix)
 ## Support My Efforts

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Guyot François](https://github.com/iFrostizz)
 - [Steve Dougherty](https://github.com/Thynix)
 - [Flying Buffalo Aerial Photography](http://flyingbuffalo.info/)
-- Sam Fingard
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Calanish](https://github.com/calanish)
 - [Lachlan Bell](https://lachy.io/)
 - [Jonny Bergdahl](https://github.com/bergdahl)
-- [Stephen Berry](https://github.com/berrystephenw)
-- [Steve Dougherty](https://github.com/Thynix)
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - Andreas Lindermayr
 - [@TheTuxKeeper](https://github.com/thetuxkeeper)
 - [@tideline3d](https://github.com/tideline3d/)
+- [SimplyPrint](https://simplyprint.io/)
 - [Andrew Beeman](https://github.com/Kiendeleo)
 - [Calanish](https://github.com/calanish)
 - [Lachlan Bell](https://lachy.io/)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [Leigh Johnson](https://github.com/leigh-johnson)
 - [Stephen Berry](https://github.com/berrystephenw)
 - [Guyot François](https://github.com/iFrostizz)
-- César Romero
 - [Steve Dougherty](https://github.com/Thynix)
 - [Kyle Menigoz](https://menigoz.me)
 ## Support My Efforts

--- a/octoprint_domoticz/__init__.py
+++ b/octoprint_domoticz/__init__.py
@@ -304,7 +304,6 @@ class domoticzPlugin(
             "checkStatus": ["ip", "idx"],
             "connectPrinter": [],
             "disconnectPrinter": [],
-            "sysCommand": ["cmd"],
         }
 
     def on_api_command(self, command, data):
@@ -359,11 +358,6 @@ class domoticzPlugin(
         elif command == "disconnectPrinter":
             self._domoticz_logger.debug("Disconnecting printer.")
             self._printer.disconnect()
-        elif command == "sysCommand":
-            self._domoticz_logger.debug(
-                "Running system command %s." % "{cmd}".format(**data)
-            )
-            os.system("{cmd}".format(**data))
 
     ##~~ Gcode processing hook
 

--- a/octoprint_domoticz/static/js/domoticz.js
+++ b/octoprint_domoticz/static/js/domoticz.js
@@ -217,19 +217,6 @@ $(function() {
 			});
 		}
 
-		self.sysCommand = function(sysCmd) {
-			$.ajax({
-				url: API_BASEURL + "plugin/domoticz",
-				type: "POST",
-				dataType: "json",
-				data: JSON.stringify({
-					command: "sysCommand",
-					cmd: sysCmd
-				}),
-				contentType: "application/json; charset=UTF-8"
-			});
-		}
-
 		self.checkStatuses = function() {
 			ko.utils.arrayForEach(self.settings.settings.plugins.domoticz.arrSmartplugs(),function(item){
 				if(item.ip() !== "") {

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_domoticz"
 plugin_name = "OctoPrint-Domoticz"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.3"
+plugin_version = "0.1.4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
add passcode options, https://github.com/jneilliii/OctoPrint-Domoticz/issues/18
switch to custom permissions to replace deprecated user_permission
add release channels available in OctoPrint 1.5.0+.
switched to basic authentication for API, https://github.com/jneilliii/OctoPrint-Domoticz/issues/24