### PR TITLE
feat: format settings window for better usability

### DIFF
--- a/octoprint_domoticz/templates/domoticz_settings.jinja2
+++ b/octoprint_domoticz/templates/domoticz_settings.jinja2
@@ -72,11 +72,13 @@
 			</tr>
 			<tr data-bind="visible: gcodeEnabled">
 				<td colspan="2">
+					<span class="control">On: </span>
 					<span class="label" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled"></span>
 					<a href="javascript:void(0)" title="Copy GCode to Clipboard" class="control-text" data-bind="click: function() { copyToClipboard($root.gcodeOnString($data)); }"><i class="fas fa-copy"></i></a>
 			</tr>
             <tr data-bind="visible: gcodeEnabled">
 				<td colspan="2">
+					<span class="control">Off: </span>
                     <span class="label" title="Use this gcode command to power off relay." data-bind="text: $root.gcodeOffString($data),visible: gcodeEnabled"></span>
 					<a href="javascript:void(0)" title="Copy GCode to Clipboard" class="control-text" data-bind="click: function() { copyToClipboard($root.gcodeOffString($data)); }"><i class="fas fa-copy"></i></a>
                 </td>

--- a/octoprint_domoticz/templates/domoticz_settings.jinja2
+++ b/octoprint_domoticz/templates/domoticz_settings.jinja2
@@ -72,14 +72,13 @@
 			</tr>
 			<tr data-bind="visible: gcodeEnabled">
 				<td colspan="2">
-                    <span class="label" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled"></span>
-                    <button type="button" class="btn btn-mini" data-bind="click: function() { copyTextToClipboard($root.gcodeOnString($data)); }">Copy All</button>
-                </td>
-            </tr>
+					<span class="control-text" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled"></span>
+					<a href="javascript:void(0)" title="Copy GCode to Clipboard" class="control-text" data-bind="click: function() { copyToClipboard($root.gcodeOnString($data)); }"><i class="fas fa-copy"></i></a>
+			</tr>
             <tr data-bind="visible: gcodeEnabled">
 				<td colspan="2">
                     <span class="label" title="Use this gcode command to power off relay." data-bind="text: $root.gcodeOffString($data),visible: gcodeEnabled"></span>
-                    <button type="button" class="btn btn-mini" data-bind="click: function() { copyTextToClipboard($root.gcodeOffString($data)); }">Copy All</button>
+					<a href="javascript:void(0)" title="Copy GCode to Clipboard" class="control-text" data-bind="click: function() { copyToClipboard($root.gcodeOnString($data)); }"><i class="fas fa-copy"></i></a>
                 </td>
             </tr>
 			<tr data-bind="visible: gcodeEnabled">
@@ -101,17 +100,3 @@
 		<a href="#" class="btn" data-dismiss="modal" aria-hidden="true">{{ _('Close') }}</a>
 	</div>
 </div>
-<script type="text/javascript">
-    function copyTextToClipboard(text) {
-        if (navigator.clipboard) {
-            navigator.clipboard.writeText(text);
-        } else {
-            var textarea = document.createElement("textarea");
-            textarea.value = text;
-            document.body.appendChild(textarea);
-            textarea.select();
-            document.execCommand("copy");
-            document.body.removeChild(textarea);
-        }
-    }
-</script>

--- a/octoprint_domoticz/templates/domoticz_settings.jinja2
+++ b/octoprint_domoticz/templates/domoticz_settings.jinja2
@@ -71,10 +71,16 @@
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: gcodeEnabled"/> GCODE Trigger</label></div></td>
 			</tr>
 			<tr data-bind="visible: gcodeEnabled">
-			<td><span class="label" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled"></span></td>
+				<td colspan="2">
+					<span class="label" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled" id="gcodeOnLabel"></span>
+					<button type="button" class="btn btn-mini" onclick="copyToClipboard('gcodeOnLabel')">Copy All</button>
+				</td>
 			</tr>
 			<tr data-bind="visible: gcodeEnabled">
-			<td><span class="label" title="Use this gcode command to power off relay." data-bind="text: $root.gcodeOffString($data),visible: gcodeEnabled"></span></td>
+				<td colspan="2">
+					<span class="label" title="Use this gcode command to power off relay." data-bind="text: $root.gcodeOffString($data),visible: gcodeEnabled" id="gcodeOffLabel"></span>
+					<button type="button" class="btn btn-mini" onclick="copyToClipboard('gcodeOffLabel')">Copy All</button>
+				</td>
 			</tr>
 			<tr data-bind="visible: gcodeEnabled">
 				<td><div class="controls"><label class="control-label">{{ _('GCODE On Delay') }}</label><input type="text" data-bind="value: gcodeOnDelay" class="input input-small" /></div></td>
@@ -95,3 +101,12 @@
 		<a href="#" class="btn" data-dismiss="modal" aria-hidden="true">{{ _('Close') }}</a>
 	</div>
 </div>
+<script type="text/javascript">
+function copyToClipboard(elementId) {
+    var el = document.getElementById(elementId);
+    if (el) {
+        var text = el.innerText || el.textContent;
+        navigator.clipboard.writeText(text);
+    }
+}
+</script>

--- a/octoprint_domoticz/templates/domoticz_settings.jinja2
+++ b/octoprint_domoticz/templates/domoticz_settings.jinja2
@@ -72,16 +72,16 @@
 			</tr>
 			<tr data-bind="visible: gcodeEnabled">
 				<td colspan="2">
-					<span class="label" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled" id="gcodeOnLabel"></span>
-					<button type="button" class="btn btn-mini" onclick="copyToClipboard('gcodeOnLabel')">Copy All</button>
-				</td>
-			</tr>
-			<tr data-bind="visible: gcodeEnabled">
+                    <span class="label" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled"></span>
+                    <button type="button" class="btn btn-mini" data-bind="click: function() { copyTextToClipboard($root.gcodeOnString($data)); }">Copy All</button>
+                </td>
+            </tr>
+            <tr data-bind="visible: gcodeEnabled">
 				<td colspan="2">
-					<span class="label" title="Use this gcode command to power off relay." data-bind="text: $root.gcodeOffString($data),visible: gcodeEnabled" id="gcodeOffLabel"></span>
-					<button type="button" class="btn btn-mini" onclick="copyToClipboard('gcodeOffLabel')">Copy All</button>
-				</td>
-			</tr>
+                    <span class="label" title="Use this gcode command to power off relay." data-bind="text: $root.gcodeOffString($data),visible: gcodeEnabled"></span>
+                    <button type="button" class="btn btn-mini" data-bind="click: function() { copyTextToClipboard($root.gcodeOffString($data)); }">Copy All</button>
+                </td>
+            </tr>
 			<tr data-bind="visible: gcodeEnabled">
 				<td><div class="controls"><label class="control-label">{{ _('GCODE On Delay') }}</label><input type="text" data-bind="value: gcodeOnDelay" class="input input-small" /></div></td>
 				<td><div class="controls"><label class="control-label">{{ _('GCODE Off Delay') }}</label><input type="text" data-bind="value: gcodeOffDelay" class="input input-small" /></div></td>
@@ -102,11 +102,16 @@
 	</div>
 </div>
 <script type="text/javascript">
-function copyToClipboard(elementId) {
-    var el = document.getElementById(elementId);
-    if (el) {
-        var text = el.innerText || el.textContent;
-        navigator.clipboard.writeText(text);
+    function copyTextToClipboard(text) {
+        if (navigator.clipboard) {
+            navigator.clipboard.writeText(text);
+        } else {
+            var textarea = document.createElement("textarea");
+            textarea.value = text;
+            document.body.appendChild(textarea);
+            textarea.select();
+            document.execCommand("copy");
+            document.body.removeChild(textarea);
+        }
     }
-}
 </script>

--- a/octoprint_domoticz/templates/domoticz_settings.jinja2
+++ b/octoprint_domoticz/templates/domoticz_settings.jinja2
@@ -72,13 +72,13 @@
 			</tr>
 			<tr data-bind="visible: gcodeEnabled">
 				<td colspan="2">
-					<span class="control-text" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled"></span>
+					<span class="label" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled"></span>
 					<a href="javascript:void(0)" title="Copy GCode to Clipboard" class="control-text" data-bind="click: function() { copyToClipboard($root.gcodeOnString($data)); }"><i class="fas fa-copy"></i></a>
 			</tr>
             <tr data-bind="visible: gcodeEnabled">
 				<td colspan="2">
                     <span class="label" title="Use this gcode command to power off relay." data-bind="text: $root.gcodeOffString($data),visible: gcodeEnabled"></span>
-					<a href="javascript:void(0)" title="Copy GCode to Clipboard" class="control-text" data-bind="click: function() { copyToClipboard($root.gcodeOnString($data)); }"><i class="fas fa-copy"></i></a>
+					<a href="javascript:void(0)" title="Copy GCode to Clipboard" class="control-text" data-bind="click: function() { copyToClipboard($root.gcodeOffString($data)); }"><i class="fas fa-copy"></i></a>
                 </td>
             </tr>
 			<tr data-bind="visible: gcodeEnabled">

--- a/octoprint_domoticz/templates/domoticz_settings.jinja2
+++ b/octoprint_domoticz/templates/domoticz_settings.jinja2
@@ -69,8 +69,12 @@
 			</tr>
 			<tr>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: gcodeEnabled"/> GCODE Trigger</label></div></td>
-				<td><span class="label" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled"></span></td>
-				<td><span class="label" title="Use this gcode command to power off relay." data-bind="text: $root.gcodeOffString($data),visible: gcodeEnabled"></span></td>
+			</tr>
+			<tr data-bind="visible: gcodeEnabled">
+			<td><span class="label" title="Use this gcode command to power on relay." data-bind="text: $root.gcodeOnString($data),visible: gcodeEnabled"></span></td>
+			</tr>
+			<tr data-bind="visible: gcodeEnabled">
+			<td><span class="label" title="Use this gcode command to power off relay." data-bind="text: $root.gcodeOffString($data),visible: gcodeEnabled"></span></td>
 			</tr>
 			<tr data-bind="visible: gcodeEnabled">
 				<td><div class="controls"><label class="control-label">{{ _('GCODE On Delay') }}</label><input type="text" data-bind="value: gcodeOnDelay" class="input input-small" /></div></td>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_domoticz"
 plugin_name = "OctoPrint-Domoticz"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.1"
+plugin_version = "1.0.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
**Description:** 
Due to the latest Issues with the M80 and M81 Issue ([https://github.com/jneilliii/OctoPrint-Domoticz/issues/28](url) ), i have reviewed the plugin again.

The GCode command text fields have been moved to individual lines and adjusted (span) to two columns for better readability if URL gets long (when using FQDN).

Also a "Copy All" button has also been added to make copying the command line quick and easy.

_Version 1.0.1_:
![domoticz_settings_1 0 1](https://github.com/user-attachments/assets/33d0bf92-ad33-4371-b6c6-d595b4cd6474)

_Updated Version 1.0.2:_
![domoticz_settings_1 0 2](https://github.com/user-attachments/assets/a9eb55ed-d40d-4ed2-b3e1-a0d58d4db205)



**Successfully Tested with** :

- Octoprint Version 1.11.2 (Python 3.11.2)
- Domoticz 2025.01 (Build Hash: 89d5c900d, Python Version: 3.11.2)


PS to author: This time i used Tabstop instead spaces, readability in code is now better ;-)